### PR TITLE
Fix MSVC version querying

### DIFF
--- a/src/wrappers/msvc_wrapper.cpp
+++ b/src/wrappers/msvc_wrapper.cpp
@@ -214,13 +214,19 @@ std::map<std::string, std::string> msvc_wrapper_t::get_relevant_env_vars() {
 }
 
 std::string msvc_wrapper_t::get_program_id() {
+  const auto& pathToCL = m_args[0];
+  const auto vsFolderPos = pathToCL.rfind("Microsoft Visual Studio");
+  if (vsFolderPos != std::string::npos) {
+    return HASH_VERSION + pathToCL.substr(vsFolderPos);
+  }
+
   // TODO(m): Add things like executable file size too.
 
   // Get the version string for the compiler.
   // Just calling "cl.exe" will return the version information. Note, though, that the version
   // information is given on stderr.
   string_list_t version_args;
-  version_args += m_args[0];
+  version_args += pathToCL;
   const auto result = sys::run(version_args, true);
   if (result.std_err.empty()) {
     throw std::runtime_error("Unable to get the compiler version information string.");


### PR DESCRIPTION
When cl.exe is called with 0 arguments it writes its 'logo string' to stderr. Currently this 'logo string' is used in the cache keys.

However, when run from Visual Studio (with the use of `CLToolExe` and `CLToolPath` MSbuild properties) buildcache fails to query the version of CL.exe, because its stderr will be empty (the logo string will be displayed in the Visual Studio Output Window). This prevents caching.

Incorporating the compiler used to create the .obj files in the cache key can be done more simply: just hash the containing folder. This hash will change when:
 - A newer version of MSVC (and thus CL.exe) is installed. ✔️ 
 - A different platform-specific CL.exe is used (e.g. HostX64/arm64/cl.exe) ✔️ 
 - A different VS edition (Community, Professional, Entreprise) is used. May be too strict, better be safe than sorry.
 - The same MSVC is uninstalled and reinstalled in a different directory. 😢 **This is bad**, but will only cause a few cache misses at the next compilation. Also very rare.

Bonus: hashing will not only be more robust but probably faster too (no process start/shutdown).