### PR TITLE
MSBuild FileTracker recognizes retrieved object files as write dependencies

### DIFF
--- a/src/cache/local_cache.cpp
+++ b/src/cache/local_cache.cpp
@@ -368,6 +368,13 @@ void local_cache_t::get_file(const hasher_t::hash_t& hash,
   } else {
     file::copy(source_path, target_path);
   }
+
+#ifdef _WIN32
+  // Open the target file for writing without doing any actual writes.
+  // This forces the registration of `target_path` as written by MSBuild
+  // FileTracker - i.e. adds an entry in *.write.*.tlog files.
+  file::append("", target_path);
+#endif
 }
 
 void local_cache_t::perform_housekeeping() {


### PR DESCRIPTION
When retrieving an `.obj` file from the cache storage, buildcache first copies to a `.tmp` temporary, then moves to the target path. MSBuild's [FileTracker](https://docs.microsoft.com/en-us/visualstudio/msbuild/file-tracking?view=vs-2019) somehow misses this operation, and does not register the `.obj` from the cache as a write dependecy of a compilation.

Due to the incomplete/incorrect resulting `*write.*.tlog` files its "minimal rebuild" feature is more fragile. For example adding a new source file to a project will trigger a full rebuild of that project. Same with deleted `.obj` files.

The solution is to open the result file after a succesful move. The Windows API call is then noticed by FileTracker, even if no actual writes are done to said file.